### PR TITLE
Use openshift nodejs image

### DIFF
--- a/stage1/deployment/030-consumer/010-ImageStream-s2i.yaml
+++ b/stage1/deployment/030-consumer/010-ImageStream-s2i.yaml
@@ -11,7 +11,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: registry.redhat.io/rhoar-nodejs/nodejs-10:latest
+      name: openshift/nodejs-010-centos7:latest
     importPolicy:
       scheduled: true
     referencePolicy:


### PR DESCRIPTION
Should we use openshift image? It's a bit easier as it doesn't request access/login to the rh registry